### PR TITLE
Allow minor updates to mime 1.x dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "amazon",
     "s3"
   ],
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "contributors": [
     "TJ Holowaychuk <tj@learnboost.com>",
@@ -22,7 +22,7 @@
   },
   "bugs": "https://github.com/dwjft/knox/issues",
   "dependencies": {
-    "mime": "1.4.0",
+    "mime": "^1.4.0",
     "xml2js": "^0.4.4",
     "debug": "^2.2.0",
     "stream-counter": "^1.0.0",


### PR DESCRIPTION
Hello @dwjft,

I'm preparing to replace knox with knox-s3 in [KeystoneJS](https://github.com/keystonejs/keystone), and noticed that mime is pinned to 1.4.0. The 1.x branch of mime is still [receiving bug fixes](https://github.com/broofa/node-mime/blob/master/CHANGELOG.md), so I think it'd be useful to allow them.

This PR changes the mime dependency from `1.4.0` to `^1.4.0`, aka `>=1.4.0 <2.0.0`.

I understand that the point of the fork is to avoid a dependency issue, so making the constraints looser might seem counterintuitive, but the continuing 1.x updates indicate that the mime author takes semver seriously. I think this might be a good middle ground.

Thank you for taking the time to publish knox-s3 on npm, so that the rest of us don't have to. 🙏

Chad