### PR TITLE
Upgrade `mime` dependency 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -360,13 +360,7 @@ Client.prototype.putFile = function(src, filename, headers, fn){
   fs.stat(src, function (err, stat) {
     if (err) return fn(err);
 
-    var contentType = mime.lookup(src);
-
-    // Add charset if it's known.
-    var charset = mime.charsets.lookup(contentType);
-    if (charset) {
-      contentType += '; charset=' + charset;
-    }
+    var contentType = mime.getType(src);
 
     headers = utils.merge({
         'Content-Length': stat.size

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "bugs": "https://github.com/dwjft/knox/issues",
   "dependencies": {
-    "mime": "^1.4.0",
-    "xml2js": "^0.4.4",
     "debug": "^2.2.0",
+    "mime": "^2.2.0",
+    "once": "^1.3.0",
     "stream-counter": "^1.0.0",
-    "once": "^1.3.0"
+    "xml2js": "^0.4.4"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Upgrade `mime` 1.x to 2.x : 
1. replace `mime.lookup()` with `mime.getType()` 
2. remove `mime.charsets.lookup()`
